### PR TITLE
Adição de mais formas de envio de PAC e SEDEX

### DIFF
--- a/src/Cagartner/CorreiosConsulta/CorreiosConsulta.php
+++ b/src/Cagartner/CorreiosConsulta/CorreiosConsulta.php
@@ -15,7 +15,9 @@ class CorreiosConsulta
             'sedex_a_cobrar' => '40045',
             'sedex_10'       => '40215',
             'sedex_hoje'     => '40290',
-            'pac'            => '41106'
+            'pac'            => '41106',
+            'pac_contrato'   => '41068',
+            'sedex_contrato' => '40096',
         );
 
         $formatos = array(


### PR DESCRIPTION
Adicionados os códigos 41068 e 40096 referentes a PAC Contrato e SEDEX Contrato respectivamente. Na forma atual do plugin, mesmo colocando o id e senha da empresa, não retorna os valores corretos.