### PR TITLE
[FIX] novo endpoint para consulta de objetos

### DIFF
--- a/src/Cagartner/CorreiosConsulta/CorreiosConsulta.php
+++ b/src/Cagartner/CorreiosConsulta/CorreiosConsulta.php
@@ -149,7 +149,9 @@ class CorreiosConsulta
     {
         $curl = new Curl;
 
-        $html = $curl->simple('http://websro.correios.com.br/sro_bin/txect01$.QueryList?P_LINGUA=001&P_TIPO=001&P_COD_UNI='.$codigo);
+        $html = $curl->simple('http://www2.correios.com.br/sistemas/rastreamento/resultado_semcontent.cfm', array(
+            "Objetos" => $codigo
+        ));
 
         phpQuery::newDocumentHTML($html, $charset = 'utf-8');
 
@@ -157,11 +159,16 @@ class CorreiosConsulta
         $c = 0;
 
         foreach(phpQuery::pq('tr') as $tr){$c++;
-            if(count(phpQuery::pq($tr)->find('td')) == 3 && $c > 1)
-                $rastreamento[] = array('data'=>phpQuery::pq($tr)->find('td:eq(0)')->text(),'local'=>phpQuery::pq($tr)->find('td:eq(1)')->text(),'status'=>phpQuery::pq($tr)->find('td:eq(2)')->text());
+            if(count(phpQuery::pq($tr)->find('td')) == 2){
+                list($data, $hora, $local) = explode("<br>", phpQuery::pq($tr)->find('td:eq(0)')->html() );
+                list($status, $encaminhado)= explode("<br>", phpQuery::pq($tr)->find('td:eq(1)')->html() );
 
-            if(count(phpQuery::pq($tr)->find('td')) == 1 && $c > 1)
-                $rastreamento[count($rastreamento)-1]['encaminhado'] = phpQuery::pq($tr)->find('td:eq(0)')->text();
+                $rastreamento[] = array('data'=>trim($data) . " " . trim($hora), 'local' => trim($local), 'status' => trim(strip_tags($status)));
+
+                if (trim($encaminhado)) {
+                    $rastreamento[count($rastreamento)-1]['encaminhado'] = trim($encaminhado);
+                }
+            }
         }
 
         if(!count($rastreamento))

--- a/test/index.php
+++ b/test/index.php
@@ -12,9 +12,9 @@ print_r($consulta->cep('89062086'));
 echo "</pre>";
 echo "<hr>";
 
-echo "<h1>Rastrear: PI464134876BR</h1>";
+echo "<h1>Rastrear: PE464134876BR</h1>";
 echo "<pre>";
-print_r($consulta->rastrear('PI464134876BR'));
+print_r($consulta->rastrear('PE464134876BR'));
 echo "</pre>";
 echo "<hr>";
 


### PR DESCRIPTION
Após desativação do link de consulta dos correios, conforme informação no link:
http://www.correios.com.br/para-voce/avisos/atualizacao-do-sistema-de-rastreamento-de-objetos-sro/

Com o endpoint antigo não é mais possível efetuar consulta de objetos