### PR TITLE
Adding Laravel 5.5 package auto discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,15 @@
             "Cagartner\\CorreiosConsulta": "src/"
         }
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Cagartner\\CorreiosConsulta\\ServiceProvider"
+            ],
+            "aliases": {
+                "Correios": "Cagartner\\CorreiosConsulta\\Facade"
+            }
+        }
+    }
 }


### PR DESCRIPTION
Adicionei ao composer.json as entradas do Laravel 5.5 para auto adicionar seu pacote ao Laravel, sem precisar editar o arquivo config/app.php

[Referência](https://laravel.com/docs/master/packages#package-discovery)