### PR TITLE
Retornar primeira ocorrencia da busca

### DIFF
--- a/src/Cagartner/CorreiosConsulta/CorreiosConsulta.php
+++ b/src/Cagartner/CorreiosConsulta/CorreiosConsulta.php
@@ -204,6 +204,8 @@ class CorreiosConsulta
                     unset($dados['cidade/uf']);
 
                     $pesquisa = $dados;
+
+                    return $pesquisa;
                 }
 
                 $linha++;


### PR DESCRIPTION
Quando buscando por um cep que tem mais de 1 ocorrência acabava trazendo a última ocorrência ao invés da primeira, cep exemplo: `15813115`