### PR TITLE
Remove ocorrências de c2a0 na consulta de cep e adiciona is_array no teste de rastreio

### DIFF
--- a/src/Cagartner/CorreiosConsulta/CorreiosConsulta.php
+++ b/src/Cagartner/CorreiosConsulta/CorreiosConsulta.php
@@ -190,16 +190,16 @@ class CorreiosConsulta
                         $itens[] = trim( $texto );
                     }
                     $dados = array();
-                    $dados['logradouro'] = trim($itens[0]);
-                    $dados['bairro'] = trim($itens[1]);
-                    $dados['cidade/uf'] = trim($itens[2]);
-                    $dados['cep'] = trim($itens[3]);
+                    $dados['logradouro'] = trim($itens[0], " \t\n\r\0\x0B\xc2\xa0");
+                    $dados['bairro'] = trim($itens[1], " \t\n\r\0\x0B\xc2\xa0");
+                    $dados['cidade/uf'] = trim($itens[2], " \t\n\r\0\x0B\xc2\xa0");
+                    $dados['cep'] = trim($itens[3], " \t\n\r\0\x0B\xc2\xa0");
 
                     $dados['cidade/uf'] = explode('/', $dados['cidade/uf']);
 
-                    $dados['cidade'] = trim($dados['cidade/uf'][0]);
+                    $dados['cidade'] = trim($dados['cidade/uf'][0], " \t\n\r\0\x0B\xc2\xa0");
 
-                    $dados['uf'] = trim($dados['cidade/uf'][1]);
+                    $dados['uf'] = trim($dados['cidade/uf'][1], " \t\n\r\0\x0B\xc2\xa0");
 
                     unset($dados['cidade/uf']);
 

--- a/tests/CorreiosTest.php
+++ b/tests/CorreiosTest.php
@@ -26,7 +26,7 @@ class CorreiosTest extends TestCase
     {
         $correios = new CorreiosConsulta();
         $dados = $correios->rastrear('PO683612101BR');
-        if (count($dados) > 0) {
+        if (is_array($dados) && count($dados) > 0) {
             $entrada = array_pop($dados);
 
             $this->assertTrue($entrada['status'] === 'Objeto postado');


### PR DESCRIPTION
Boa tarde. Recentemente, acho que já faz alguns meses, o serviço de consulta de ceps do correios que é usado na sua biblioteca começou a retornar resultados com o caracter c2a0 ao final do **uf**, **logradouro**, ...

Isso significa que as consultas de cep (Não sei se todas), retornam valores com espaços no final. 
Ex:

```
array(5) {
  ["logradouro"]=>
  string(34) "Rua Doutor Evaristo Cabral Renno "
  ["bairro"]=>
  string(10) "Medicina "
  ["cep"]=>
  string(9) "37502-146"
  ["cidade"]=>
  string(8) "Itajubá"
  ["uf"]=>
  string(4) "MG "
}
```

A função [trim](https://github.com/cagartner/correios-consulta/blob/master/src/Cagartner/CorreiosConsulta/CorreiosConsulta.php#L193)  por si só não remove esse tipo de espaço em branco. É necessário adicionar um segundo parâmetro 
```php
trim($text, " \t\n\r\0\x0B\xc2\xa0")
```

com esse **PR**, a consulta de cep retornar informações sem espaços no final (o teste  `testValidZipCode` dava problema por conta desses espaços adicionisl). E o teste `testValidShipmentTracking` para de dar erro por conta do uso da função `count()` com parâmetro `false` (caso em que o código de rastreio não é encontrado nos correios e a função `rastrear` retorna `false`).
