### PR TITLE
Alteração no tratamento de espaços em branco

### DIFF
--- a/src/Cagartner/CorreiosConsulta/CorreiosConsulta.php
+++ b/src/Cagartner/CorreiosConsulta/CorreiosConsulta.php
@@ -173,7 +173,7 @@ class CorreiosConsulta
                             $innerHTML .= $child->ownerDocument->saveXML($child);
                         }
                         $texto = preg_replace("/&#?[a-z0-9]+;/i", "", $innerHTML);
-                        $itens[] = trim($texto);
+                        $itens[] = preg_replace(['(\s+)u', '(^\s|\s$)u'], [' ', ''], $texto);
                     }
                     $dados = array();
                     $dados['logradouro'] = trim($itens[0]);


### PR DESCRIPTION
Normalização de espaço em branco retornado do DOMDocument. O PHP retorna cadeias de caracteres no lugar de "espaço em branco". Substituída a função trim() por expressão regular para correção.