### PR TITLE
Corrige a função de sanitização dos valores

### DIFF
--- a/src/Cagartner/CorreiosConsulta/CorreiosConsulta.php
+++ b/src/Cagartner/CorreiosConsulta/CorreiosConsulta.php
@@ -251,7 +251,7 @@ class CorreiosConsulta
      */
     protected function cleanMoney($value)
     {
-        return (float) str_replace(',', '.', $value);
+        return (float) str_replace(',', '.', str_replace('.', '', $value));
     }
 
     /**


### PR DESCRIPTION
Em valores acima de 1000 reais, a presença de pontos como separados de milhas causa a leitura de valores incorretos.